### PR TITLE
Fixes incorrect dimensions (width, height) in img-tag of page image

### DIFF
--- a/ModulePageImage.php
+++ b/ModulePageImage.php
@@ -58,7 +58,7 @@ class ModulePageImage extends Module
 
         $this->Template->setData($arrImage);
 
-        if (($imgSize = @getimagesize(TL_ROOT . '/' . $arrImage['path'])) !== false) {
+        if (($imgSize = @getimagesize(TL_ROOT . '/' . rawurldecode($arrImage['src']))) !== false) {
             $this->Template->size = ' ' . $imgSize[3];
         }
     }


### PR DESCRIPTION
Previously the original dimensions of the image were added, not the ones specified in the frontend module.
