### PR TITLE
Responsive Image functionality 

### DIFF
--- a/ModulePageImage.php
+++ b/ModulePageImage.php
@@ -74,6 +74,10 @@ class ModulePageImage extends Module
         $arrImage['src'] = $this->getImage($arrImage['path'], $arrSize[0], $arrSize[1], $arrSize[2]);
 
         $this->Template->setData($arrImage);
+        
+        $picture = \Picture::create($arrImage['path'], $arrSize)->getTemplateData();
+        $picture['alt'] = specialchars($arrImage['alt']);
+        $this->Template->picture = $picture;
 
         if (($imgSize = @getimagesize(TL_ROOT . '/' . rawurldecode($arrImage['src']))) !== false) {
             $this->Template->size = ' ' . $imgSize[3];

--- a/templates/mod_pageimage.html5
+++ b/templates/mod_pageimage.html5
@@ -6,7 +6,6 @@
 <<?php echo $this->hl; ?>><?php echo $this->headline; ?></<?php echo $this->hl; ?>>
 <?php endif; ?>
 
-<figure class="image_container"><?php if($this->hasLink): ?><a href="<?php echo $this->href; ?>" title="<?php echo $this->title; ?>"><?php endif; ?><img src="<?php echo $this->src; ?>"<?php echo $this->size; ?> alt="<?php echo $this->alt; ?>" /><?php if($this->hasLink): ?></a><?php endif; ?></figure>
-
+<figure class="image_container"><?php if($this->hasLink): ?><a href="<?php echo $this->href; ?>" title="<?php echo $this->title; ?>"><?php endif; ?><?php $this->insert('picture_default', $this->picture); ?><?php if($this->hasLink): ?></a><?php endif; ?></figure>
 </div>
 <!-- indexer::continue -->


### PR DESCRIPTION
Code as suggested by @Flaschenzug in https://github.com/terminal42/contao-pageimage/issues/21#issuecomment-68110353 and RockSolid Themes in the community: https://community.contao.org/de/showthread.php?54576-pageimage-tempalte-f%FCr-responsive-images-anpassen&p=352529&viewfull=1#post352529

Tested it with Contao 3.5.12 and had no problems.