### PR TITLE
Do not add media query, if there is no density or media query

### DIFF
--- a/ModuleBackgroundImage.php
+++ b/ModuleBackgroundImage.php
@@ -79,15 +79,17 @@ class ModuleBackgroundImage extends ModulePageImage
                 list($src, $density) = StringUtil::trimsplit(' ', $srcset);
                 $density = rtrim($density, 'x');
 
-                $mediaQueries[] = [
-                    'mq'  => sprintf(
-                        $density > 1 ? 'screen and %1$s%2$s, screen and %1$s%3$s' : 'screen and %1$s',
-                        $value['media'] ?: '',
-                        $density > 1 ? " and (-webkit-min-device-pixel-ratio: $density)" : '',
-                        $density > 1 ? " and (min-resolution: {$density}dppx)" : ''
-                    ),
-                    'src' => $src
-                ];
+                if (!empty($density) || !empty($value['media'])) {
+                    $mediaQueries[] = [
+                        'mq'  => sprintf(
+                            $density > 1 ? 'screen and %1$s%2$s, screen and %1$s%3$s' : 'screen and %1$s',
+                            $value['media'] ?: '',
+                            $density > 1 ? " and (-webkit-min-device-pixel-ratio: $density)" : '',
+                            $density > 1 ? " and (min-resolution: {$density}dppx)" : ''
+                        ),
+                        'src' => $src
+                    ];
+                }
             }
         }
 

--- a/ModuleBackgroundImage.php
+++ b/ModuleBackgroundImage.php
@@ -79,7 +79,7 @@ class ModuleBackgroundImage extends ModulePageImage
                 list($src, $density) = StringUtil::trimsplit(' ', $srcset);
                 $density = rtrim($density, 'x');
 
-                if (!empty($density) || !empty($value['media'])) {
+                if ((!empty($density) && $density > 1) || !empty($value['media'])) {
                     $mediaQueries[] = [
                         'mq'  => sprintf(
                             $density > 1 ? 'screen and %1$s%2$s, screen and %1$s%3$s' : 'screen and %1$s',

--- a/ModuleBackgroundImage.php
+++ b/ModuleBackgroundImage.php
@@ -79,7 +79,7 @@ class ModuleBackgroundImage extends ModulePageImage
                 list($src, $density) = StringUtil::trimsplit(' ', $srcset);
                 $density = rtrim($density, 'x');
 
-                if ((!empty($density) && $density > 1) || !empty($value['media'])) {
+                if ((!empty($density) && 1 !== (int) $density) || !empty($value['media'])) {
                     $mediaQueries[] = [
                         'mq'  => sprintf(
                             $density > 1 ? 'screen and %1$s%2$s, screen and %1$s%3$s' : 'screen and %1$s',


### PR DESCRIPTION
It can happen, that the `srcset` only contains the main image, i.e. the `src`, without any density descriptor. Also, generally, a media query must only be added, if either a density is present, that is not equal to one, or a media query within the source is present. Otherwise you end up with

```css
@media screen and  {
    …
}
```