### PR TITLE
Fix endless migration

### DIFF
--- a/src/Migration/ModuleMigration.php
+++ b/src/Migration/ModuleMigration.php
@@ -23,7 +23,7 @@ class ModuleMigration extends AbstractMigration
     public function shouldRun(): bool
     {
         return $this->connection->fetchOne(
-            "SELECT COUNT(*) FROM tl_module WHERE type='pageImage' OR type='backgroundImage'"
+            "SELECT COUNT(*) FROM tl_module WHERE BINARY type='pageImage' OR BINARY type='backgroundImage'"
         ) > 0;
     }
 

--- a/src/Migration/ModuleMigration.php
+++ b/src/Migration/ModuleMigration.php
@@ -23,7 +23,7 @@ class ModuleMigration extends AbstractMigration
     public function shouldRun(): bool
     {
         return $this->connection->fetchOne(
-            "SELECT COUNT(*) FROM tl_module WHERE BINARY type='pageImage' OR BINARY type='backgroundImage'"
+            "SELECT COUNT(*) FROM tl_module WHERE type = BINARY 'pageImage' OR type = BINARY 'backgroundImage'"
         ) > 0;
     }
 


### PR DESCRIPTION
The migration runs endlessly since the column is case-insensitive. Use "BINARY" to do a case-sensitive string comparison.