### PR TITLE
Make the helper service public

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -2,7 +2,8 @@ services:
     _defaults:
         autoconfigure: true
 
-    Terminal42\PageimageBundle\PageimageHelper: ~
+    Terminal42\PageimageBundle\PageimageHelper:
+        public: true
 
     Terminal42\PageimageBundle\Controller\PageimageController:
         arguments: ['@Terminal42\PageimageBundle\PageimageHelper']


### PR DESCRIPTION
So it can be accessed e.g. via `System::getContainer()->get(\Terminal42\PageimageBundle\PageimageHelper::class)`.