### PR TITLE
Fix array access warnings in templates

### DIFF
--- a/contao/templates/mod_pageimage.html5
+++ b/contao/templates/mod_pageimage.html5
@@ -3,9 +3,9 @@
 
 <?php foreach ($this->allImages as $image): ?>
 <figure class="image_container">
-    <?php if ($image['hasLink']): ?><a href="<?= \Contao\StringUtil::specialchars($image['href']) ?>" title="<?= \Contao\StringUtil::specialchars($image['title']) ?>"><?php endif; ?>
+    <?php if ($image['hasLink'] ?? false): ?><a href="<?= \Contao\StringUtil::specialchars($image['href']) ?>" title="<?= \Contao\StringUtil::specialchars($image['title']) ?>"><?php endif; ?>
         <?php $this->insert('picture_default', $image['picture']); ?>
-    <?php if ($image['hasLink']): ?></a><?php endif; ?>
+    <?php if ($image['hasLink'] ?? false): ?></a><?php endif; ?>
 </figure>
 <?php endforeach; ?>
 

--- a/contao/templates/mod_pageimage_slider.html5
+++ b/contao/templates/mod_pageimage_slider.html5
@@ -7,9 +7,9 @@
 
     <?php foreach ($this->allImages as $image): ?>
       <figure class="image_container">
-        <?php if ($image['hasLink']): ?><a href="<?= \Contao\StringUtil::specialchars($image['href']) ?>" title="<?= \Contao\StringUtil::specialchars($image['title']) ?>"><?php endif; ?>
+        <?php if ($image['hasLink'] ?? false): ?><a href="<?= \Contao\StringUtil::specialchars($image['href']) ?>" title="<?= \Contao\StringUtil::specialchars($image['title']) ?>"><?php endif; ?>
           <?php $this->insert('picture_default', $image['picture']); ?>
-          <?php if ($image['hasLink']): ?></a><?php endif; ?>
+          <?php if ($image['hasLink'] ?? false): ?></a><?php endif; ?>
       </figure>
     <?php endforeach; ?>
 


### PR DESCRIPTION
Fixes the following warning(s):

```
ErrorException:
Warning: Undefined array key "hasLink"

  at vendor\terminal42\contao-pageimage\contao\templates\mod_pageimage.html5:6
  at include('vendor\\terminal42\\contao-pageimage\\contao\\templates\\mod_pageimage.html5')
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\TemplateInheritance.php:108)
```