### PR TITLE
Allow image to not exist

### DIFF
--- a/src/Controller/PageimageController.php
+++ b/src/Controller/PageimageController.php
@@ -119,7 +119,7 @@ class PageimageController extends AbstractFrontendModuleController
                     $mediaQueries[] = [
                         'mq' => \sprintf(
                             $density > 1 ? 'screen %1$s%2$s, screen and %1$s%3$s' : 'screen and %1$s',
-                            ($value['media'] ?? null) ? " and {$value['media']}" : '',
+                            $value['media'] ?? null ? " and {$value['media']}" : '',
                             $density > 1 ? " and (-webkit-min-device-pixel-ratio: $density)" : '',
                             $density > 1 ? " and (min-resolution: {$density}dppx)" : '',
                         ),

--- a/src/Controller/PageimageController.php
+++ b/src/Controller/PageimageController.php
@@ -33,10 +33,12 @@ class PageimageController extends AbstractFrontendModuleController
         }
 
         $templateData = [];
-        $figure = $this->studio->createFigureBuilder()->setSize($model->imgSize);
+        $figureBuilder = $this->studio->createFigureBuilder()->setSize($model->imgSize);
 
         foreach ($images as $image) {
-            if (!$figure = $figure->from($image['path'])->buildIfResourceExists()) {
+            $figure = $figureBuilder->from($image['path'])->buildIfResourceExists();
+
+            if (!$figure) {
                 continue;
             }
 
@@ -46,7 +48,7 @@ class PageimageController extends AbstractFrontendModuleController
             );
         }
 
-        if (empty($templateData)) {
+        if (!$templateData) {
             return new Response();
         }
 


### PR DESCRIPTION
If an image exists in the DBAFS but not on the local file system, an error currently occurs. This PR would allow selected images to not exist.

_Note:_ the `($value['media'] ?? null)` change is actually an unrelated warning that can occur in the debug mode with images that have additional densities, but no media queries.